### PR TITLE
Submitter completion separation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,14 @@
 {
 	"name": "Rust",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye"
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"vadimcn.vscode-lldb"
+			]
+		}
+	}
 
 	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
 	// "mounts": [

--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ The API supports `*Direct` commands for usage with direct IO in the form of oper
 
 It also uses micro-batching, so when it goes to submit more command entries to the queue it will drain the channel up to a certain amount, submit all of the entries, grab all of the results, and send them over the responder channels.
 
-It's fast, ran many times this is a (visibly checked) median-ish run to read and write `Hello, world!\n`:
+It's fast, ran many times this is a (visibly checked) median-ish run to read and write `Hello, world!\n` (fsync and not):
 ```
-2025-01-20T18:43:08.193672Z DEBUG write: src/io_uring.rs:162: close time.busy=2.62µs time.idle=151µs
-2025-01-20T18:43:08.193756Z DEBUG read: src/io_uring.rs:131: close time.busy=2.12µs time.idle=77.1µs
+2025-01-21T17:47:56.349957Z DEBUG src/io_uring.rs:228: Starting actor loop
+2025-01-21T17:47:56.350043Z DEBUG write: src/io_uring.rs:175: close time.busy=6.00µs time.idle=81.5µs fsync=false
+2025-01-21T17:47:56.350110Z DEBUG read: src/io_uring.rs:142: close time.busy=5.75µs time.idle=55.5µs
+Read data (string): Hello, world!
+
+2025-01-21T17:47:56.350254Z DEBUG write: src/io_uring.rs:175: close time.busy=5.13µs time.idle=130µs fsync=true
+2025-01-21T17:47:56.350282Z DEBUG read: src/io_uring.rs:142: close time.busy=4.83µs time.idle=18.5µs
+Read data (string): Hello, world again!
 ```

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -47,7 +47,7 @@ mod linux_impl {
 
     use super::AlignedBuffer;
     use flume::{Receiver, Sender, TryRecvError};
-    use io_uring::{opcode, CompletionQueue, IoUring};
+    use io_uring::{opcode, CompletionQueue, IoUring, SubmissionQueue};
     use tokio::task::yield_now;
     use tracing::{debug, error, info, instrument, trace, warn};
 
@@ -211,14 +211,78 @@ mod linux_impl {
         receiver: Receiver<IOUringActorCommand>,
     }
 
-    impl<const BLOCK_SIZE: usize> IOUringActor<BLOCK_SIZE> {
+    impl<'a, const BLOCK_SIZE: usize> IOUringActor<BLOCK_SIZE> {
         // TODO: Read
         // TODO: Write
         // TODO: Delete (calls trim)
         async fn run(mut self) {
             debug!("Starting actor loop");
-            let (completion_sender, completion_receiver) = flume::unbounded();
-            tokio::spawn(self.completion_loop(self.ring.completion_shared(), completion_receiver));
+            let (completion_sender, completion_receiver) = flume::unbounded::<(
+                &Sender<Result<IOUringActorResponse, std::io::Error>>,
+                IOUringActorResponse,
+                i32,
+            )>();
+
+            // Create a separate task that only processes completions
+            let completion_queue = self.ring.completion();
+            let submission_queue = self.ring.submission();
+            tokio::spawn(async move {
+                loop {
+                    // Wait for a completion request
+                    let (sender, response, wait_for_extra) =
+                        match completion_receiver.recv_async().await {
+                            Ok(result) => result,
+                            Err(_) => {
+                                info!("Completion receiver disconnected");
+                                return;
+                            }
+                        };
+
+                    // Process the completion without holding across await points
+                    let mut result = None;
+
+                    // Wait for completion
+                    while completion_queue.is_empty() {
+                        yield_now().await;
+                    }
+
+                    // Process the completion
+                    if let Some(cqe) = completion_queue.next() {
+                        result = Some(if cqe.result() < 0 {
+                            Err(std::io::Error::from_raw_os_error(-cqe.result()))
+                        } else {
+                            Ok(response)
+                        });
+                    }
+
+                    // Handle extra completions if needed
+                    if wait_for_extra > 0 && result.as_ref().map_or(false, |r| r.is_ok()) {
+                        for _ in 0..wait_for_extra {
+                            while completion_queue.is_empty() {
+                                yield_now().await;
+                            }
+
+                            if let Some(cqe) = completion_queue.next() {
+                                if cqe.result() < 0 {
+                                    result =
+                                        Some(Err(std::io::Error::from_raw_os_error(-cqe.result())));
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    // Send the final result
+                    let result = result.unwrap_or_else(|| {
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            "No completion queue entry found",
+                        ))
+                    });
+                    let _ = sender.send_async(result).await;
+                }
+            });
+
             const MAX_COMMANDS: usize = 10; // TODO: Make this configurable
             loop {
                 let mut responders: Vec<(
@@ -257,7 +321,10 @@ mod linux_impl {
                             sender,
                         } => {
                             debug!("Read: {:?}", offset);
-                            match self.handle_read(*offset, *size).await {
+                            match self
+                                .handle_read(&mut submission_queue, *offset, *size)
+                                .await
+                            {
                                 Ok(result) => (sender, IOUringActorResponse::Read(result), 0),
                                 Err(e) => {
                                     debug!("handle_read error: {:?}", e);
@@ -275,7 +342,10 @@ mod linux_impl {
                             sender,
                         } => {
                             debug!("WriteBlock: {:?}", offset);
-                            match self.handle_write(*offset, &buffer, *fsync).await {
+                            match self
+                                .handle_write(&mut submission_queue, *offset, &buffer, *fsync)
+                                .await
+                            {
                                 Ok(()) => (
                                     sender,
                                     IOUringActorResponse::Write,
@@ -326,90 +396,12 @@ mod linux_impl {
             }
         }
 
-        async fn completion_loop(
+        async fn handle_read(
             &mut self,
-            mut ceq: CompletionQueue<'_>,
-            completion_receiver: Receiver<(
-                flume::Sender<Result<IOUringActorResponse, std::io::Error>>,
-                IOUringActorResponse,
-                usize,
-            )>,
-        ) {
-            // Process completion - Modified to not hold completion queue across await
-            let (sender, response, wait_for_extra) = match completion_receiver.recv_async().await {
-                Ok(result) => result,
-                Err(e) => {
-                    info!("Completion receiver disconnected");
-                    return;
-                }
-            };
-            // First we wait for a completion in the ring
-            while ceq.is_empty() {
-                yield_now().await; // yield to the scheduler to avoid busy-waiting
-            }
-
-            // We finally got an entry, let's take it
-            let result = ceq.next();
-            match result {
-                Some(cqe) => {
-                    let result = if cqe.result() < 0 {
-                        debug!("Completion error: {:?}", cqe.result());
-                        Err(std::io::Error::from_raw_os_error(-cqe.result()))
-                    } else {
-                        Ok(response)
-                    };
-
-                    // Definitely a better way to write this
-                    if wait_for_extra > 0 {
-                        trace!("Waiting for extra completion");
-                        for _ in 0..wait_for_extra {
-                            // First we wait for a completion in the ring
-                            while ceq.is_empty() {
-                                yield_now().await; // yield to the scheduler to avoid busy-waiting
-                            }
-
-                            let extra_result = ceq.next();
-                            let extra_result = match extra_result {
-                                Some(cqe) => {
-                                    let result = if cqe.result() < 0 {
-                                        Err(std::io::Error::from_raw_os_error(-cqe.result()))
-                                    } else {
-                                        Ok(())
-                                    };
-                                    result
-                                }
-                                None => {
-                                    error!("No completion queue entry found for extra operation");
-                                    Err(std::io::Error::new(
-                                        std::io::ErrorKind::Other,
-                                        "No completion queue entry found for extra operation",
-                                    ))
-                                }
-                            };
-                            if let Err(e) = extra_result {
-                                let _ = sender.send_async(Err(e)).await;
-                            }
-                        }
-                    }
-
-                    // Now we can await after we're done with the completion queue since it's not Send,
-                    // and we don't care about the result of the send
-                    let _ = sender.send_async(result).await;
-                }
-                None => {
-                    // TODO: better log on this
-                    error!("No completion queue entry found");
-                    let _ = sender
-                        .send_async(Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            "No completion queue entry found",
-                        )))
-                        .await;
-                }
-            }
-        }
-
-        async fn handle_read(&mut self, offset: u64, size: usize) -> std::io::Result<Vec<u8>> {
+            submission_queue: &mut SubmissionQueue<'a>,
+            offset: u64,
+            size: usize,
+        ) -> std::io::Result<Vec<u8>> {
             let mut buffer = vec![0u8; size];
             let read_e = opcode::Read::new(self.fd, buffer.as_mut_ptr(), buffer.len() as _)
                 .offset(offset)
@@ -417,25 +409,10 @@ mod linux_impl {
                 .user_data(0x42);
 
             unsafe {
-                self.ring
-                    .submission()
+                submission_queue
                     .push(&read_e)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             }
-
-            // self.ring.submit()?;
-
-            // TODO: just submit and let caller wait
-            // self.ring.submit_and_wait(1)?;
-
-            // // Process completion
-            // while let Some(cqe) = self.ring.completion().next() {
-            //     if cqe.result() < 0 {
-            //         return Err(std::io::Error::from_raw_os_error(-cqe.result()));
-            //     }
-            // }
-
-            // println!("Read completed {:?}", buffer);
 
             Ok(buffer)
         }
@@ -443,6 +420,7 @@ mod linux_impl {
         /// Reads a block from the device into the given buffer.
         async fn handle_read_direct<T: AlignedBuffer>(
             &mut self,
+            submission_queue: &mut SubmissionQueue<'a>,
             offset: u64,
             buffer: &mut T,
         ) -> std::io::Result<()> {
@@ -452,20 +430,9 @@ mod linux_impl {
                 .user_data(0x42);
 
             unsafe {
-                self.ring
-                    .submission()
+                submission_queue
                     .push(&read_e)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-            }
-
-            // TODO: just submit and let caller wait
-            self.ring.submit_and_wait(1)?;
-
-            // Process completion
-            while let Some(cqe) = self.ring.completion().next() {
-                if cqe.result() < 0 {
-                    return Err(std::io::Error::from_raw_os_error(-cqe.result()));
-                }
             }
 
             Ok(())
@@ -473,7 +440,8 @@ mod linux_impl {
 
         /// Writes data, returning after submission
         async fn handle_write(
-            &mut self,
+            &self,
+            submission_queue: &mut SubmissionQueue<'a>,
             offset: u64,
             buffer: &[u8],
             fsync: bool,
@@ -485,8 +453,7 @@ mod linux_impl {
                 .user_data(0x43);
 
             unsafe {
-                self.ring
-                    .submission()
+                submission_queue
                     .push(&write_e)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             }
@@ -499,8 +466,7 @@ mod linux_impl {
             let fsync_e = opcode::Fsync::new(self.fd).build().user_data(0x44);
 
             unsafe {
-                self.ring
-                    .submission()
+                submission_queue
                     .push(&fsync_e)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             }

--- a/src/io_uring.rs
+++ b/src/io_uring.rs
@@ -259,14 +259,7 @@ mod linux_impl {
                 } else {
                     trace!("No command to submit");
                 }
-                // println!(
-                //     "ring: {:?} responders: {:?}",
-                //     self.ring.completion().len(),
-                //     responders.len()
-                // );
-                // if self.ring.completion().len() > 0 && responders.len() > 0 {
-                //     println!("Checking for completion");
-                // }
+
                 // If we have responders, let's check if the tasks are completed
                 while self.ring.completion().len() > 0 && responders.len() > 0 {
                     trace!(
@@ -442,20 +435,6 @@ mod linux_impl {
                     .push(&read_e)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             }
-
-            // self.ring.submit()?;
-
-            // TODO: just submit and let caller wait
-            // self.ring.submit_and_wait(1)?;
-
-            // // Process completion
-            // while let Some(cqe) = self.ring.completion().next() {
-            //     if cqe.result() < 0 {
-            //         return Err(std::io::Error::from_raw_os_error(-cqe.result()));
-            //     }
-            // }
-
-            // println!("Read completed {:?}", buffer);
 
             Ok(buffer)
         }


### PR DESCRIPTION
Loops through, tracking active commands that are submitted and polls for their completion. By doing this as one loop that doesn't block (we keep our own queue of submitted commands) we remove the batch-wait cost that currently exists, by continuing the loop to check for more commands to submit instead.

Closes #1 